### PR TITLE
Python unico

### DIFF
--- a/lab/tutorials/flask/Dockerfile
+++ b/lab/tutorials/flask/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.9-alpine
+FROM python:3.9-slim
+#FROM python:3.9-alpine
 
 RUN mkdir -p /opt/app
 WORKDIR /opt/app


### PR DESCRIPTION
Consiglierei di tenere una sola versione python, visto che nei progetti successivi si usa la slim ho commentato la richiesta della alpine. Ciao